### PR TITLE
Added stake info (estimatestakediff and ticketsmempool)

### DIFF
--- a/app.js
+++ b/app.js
@@ -97,11 +97,6 @@ var connect = function() {
 						console.log('Socket error: ' + err);
 					}
 				});
-			ws.send('{"jsonrpc":"1.0","id":"getticketpoolvalue","method":"getticketpoolvalue","params":[]}', function(err) {
-					if (err) {
-						console.log('Socket error: ' + err);
-					}
-				});
 	  		ws.send('{"jsonrpc":"1.0","id":"ticketsmempool","method":"getrawmempool","params":[false, "tickets"]}', function(err) {
 					if (err) {
 						console.log('Socket error: ' + err);
@@ -124,6 +119,15 @@ var connect = function() {
 					}
 				});
 	  	}, 60000);
+
+	  	// except for getticketpoolvalue which eats a huge amount of CPU, so run it less frequently.
+	  //   var activeNodesInterval = setInterval(function() {
+			// ws.send('{"jsonrpc":"1.0","id":"getticketpoolvalue","method":"getticketpoolvalue","params":[]}', function(err) {
+			// 		if (err) {
+			// 			console.log('Socket error: ' + err);
+			// 		}
+			// 	});
+	  // 	}, 5 * 60000);
 
 	});
 
@@ -264,6 +268,13 @@ function addNewBlock (block) {
 				console.log('Socket error: ' + err);
 			}
 		});
+	// I might want to update getticketpoolvalue when i get a new block too
+	ws.send('{"jsonrpc":"1.0","id":"getticketpoolvalue","method":"getticketpoolvalue","params":[]}', function(err) {
+			if (err) {
+				console.log('Socket error: ' + err);
+			}
+		});
+
 }
 
 function updateSupply (data) {

--- a/app.js
+++ b/app.js
@@ -90,41 +90,34 @@ var connect = function() {
 				}
 			});
 
-	    /* Update peer list each minute */
+	    /* Update stuff each minute */
 	    var activeNodesInterval = setInterval(function() {
-	      ws.send('{"jsonrpc":"1.0","id":"getpeerinfo","method":"getpeerinfo","params":[]}', function(err) {
+	    	ws.send('{"jsonrpc":"1.0","id":"getpeerinfo","method":"getpeerinfo","params":[]}', function(err) {
 					if (err) {
 						console.log('Socket error: ' + err);
 					}
 				});
-	    }, 60000);
-
-	    /* Update locked DCR in PoS each 5 minutes */
-	    var lockedCoinsInterval = setInterval(function() {
-	      ws.send('{"jsonrpc":"1.0","id":"getticketpoolvalue","method":"getticketpoolvalue","params":[]}', function(err) {
+			ws.send('{"jsonrpc":"1.0","id":"getticketpoolvalue","method":"getticketpoolvalue","params":[]}', function(err) {
 					if (err) {
 						console.log('Socket error: ' + err);
 					}
 				});
-	    }, 60000);
-
-	    var hashrateCheck = setInterval( function () {
+	  		ws.send('{"jsonrpc":"1.0","id":"ticketsmempool","method":"getrawmempool","params":[false, "tickets"]}', function(err) {
+					if (err) {
+						console.log('Socket error: ' + err);
+					}
+				});
+				//dcrctl getrawmempool false tickets
+//	  		ws.send('{"jsonrpc":"1.0","id":"getstakeinfo","method":"getstakeinfo","params":[]}', function(err) {
+//					if (err) {
+//						console.log('Socket error: ' + err);
+//					}
+//				});
 	  		ws.send('{"jsonrpc":"1.0","id":"getmininginfo","method":"getmininginfo","params":[]}', function(err) {
 					if (err) {
 						console.log('Socket error: ' + err);
 					}
 				});
-	  	}, 60000);
-
-	    var hashrateCheck = setInterval( function () {
-	  		ws.send('{"jsonrpc":"1.0","id":"getstakeinfo","method":"getstakeinfo","params":[]}', function(err) {
-					if (err) {
-						console.log('Socket error: ' + err);
-					}
-				});
-	  	}, 60000);
-
-	    var hashrateCheck = setInterval( function () {
 	  		ws.send('{"jsonrpc":"1.0","id":"estimatestakediff","method":"estimatestakediff","params":[]}', function(err) {
 					if (err) {
 						console.log('Socket error: ' + err);
@@ -137,7 +130,6 @@ var connect = function() {
 	ws.on('message', function(data, flags) {
 
 	    try {
-			console.log(data);
 	    	data = JSON.parse(data);
 	    } catch(e) {
 	    	console.log(e);
@@ -169,6 +161,8 @@ var connect = function() {
 	      updateNetworkHashrate(result);
 		} else if (result && data.id && data.id == 'getstakeinfo') {
 		    updateStake(result);
+		} else if (result && data.id && data.id == 'ticketsmempool') {
+		    updateTicketsMempool(result);
 		} else if (result && data.id && data.id == 'estimatestakediff') {
 	      updateEstimateStake(result);
 		} else if (result && data.id && data.id == 'getpeerinfo') {
@@ -316,6 +310,21 @@ function updateNetworkHashrate (data) {
       console.success('API', 'UPD', 'Updated mininginfo');
       client.write({
         action: 'mininginfo',
+        data: stats
+      });
+    }
+  });
+}
+
+function updateTicketsMempool (data) {
+  Nodes.updateTicketsMempool(data, function (err, stats) {
+    if(err !== null)
+    {
+      console.error('API', 'BLK', 'TicketsMempool error:', err);
+    } else {
+      console.success('API', 'UPD', 'Updated TicketsMempool info');
+      client.write({
+        action: 'tiketsmempool',
         data: stats
       });
     }

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -118,6 +118,10 @@ Collection.prototype.updateStakeInfo = function(stats, callback) {
 		this._blockchain.updateStakeInfo(stats, callback);
 }
 
+Collection.prototype.updateTicketsMempool = function(stats, callback) {
+		this._blockchain.updateTicketsMempool(stats, callback);
+}
+
 Collection.prototype.updateEstimateStake = function(stats, callback) {
 		this._blockchain.updateEstimateStake(stats, callback);
 }

--- a/lib/collection.js
+++ b/lib/collection.js
@@ -114,6 +114,14 @@ Collection.prototype.updateMiningInfo = function(stats, callback) {
 		this._blockchain.updateMiningInfo(stats, callback);
 }
 
+Collection.prototype.updateStakeInfo = function(stats, callback) {
+		this._blockchain.updateStakeInfo(stats, callback);
+}
+
+Collection.prototype.updateEstimateStake = function(stats, callback) {
+		this._blockchain.updateEstimateStake(stats, callback);
+}
+
 Collection.prototype.updatePending = function(id, stats, callback)
 {
 	var node = this.getNode({ id: id });

--- a/lib/history.js
+++ b/lib/history.js
@@ -19,6 +19,14 @@ var History = function History(data)
 	this.supply = 0;
 	this.locked = 0;
 	this._callback = null;
+	this.tixpoolsize = 0;
+	this.allmempooltix = 0;
+	this.stakedifficulty = 0;
+	this.estimatemin = 0;
+	this.estimatemax = 0;
+	this.estimateexpected = 0;
+
+
 }
 
 History.prototype.add = function(block, id, trusted, addingHistory)
@@ -481,6 +489,53 @@ History.prototype.updateMiningInfo = function(stats, callback) {
 	return callback(null, stats);
 }
 
+History.prototype.updateEstimateStake = function(stats, callback) {
+	this.estimatemin = stats.min;
+	this.estimatemax = stats.max;
+	this.estimateexpected = stats.expected;
+
+	return callback(null, stats);
+}
+
+History.prototype.updateStakeInfo = function(stats, callback) {
+
+	this.tixpoolsize = stats.poolsize;
+	this.allmempooltix = stats.allmempooltix;
+	this.stakedifficulty = stats.difficulty;
+
+	return callback(null, stats);
+}
+
+History.prototype.getEstimateMin = function()
+{
+	return this.estimatemin;
+}
+History.prototype.getEstimateMax = function()
+{
+	return this.estimatemax;
+}
+History.prototype.getEstimateExpected = function()
+{
+	return this.estimateexpected;
+}
+
+
+History.prototype.getTixPoolSize = function()
+{
+	return this.tixpoolsize;
+}
+
+History.prototype.getMemPoolTix = function()
+{
+	return this.allmempooltix;
+}
+
+History.prototype.getStakeDifficulty = function()
+{
+	return this.stakedifficulty;
+}
+
+
 History.prototype.getAvgHashrate = function()
 {
 	return this.avgHashrate;
@@ -557,7 +612,13 @@ History.prototype.getCharts = function()
 			supply : this.supply,
 			locked : this.locked,
 			pooledtx : this.pooledtx,
-			avgHashrate : this.getAvgHashrate()
+			avgHashrate : this.getAvgHashrate(),
+			tixpoolsize : this.getTixPoolSize(),
+			allmempooltix : this.getMemPoolTix(),
+			stakedifficulty : this.getStakeDifficulty(),
+			estimatemin : this.estimatemin,
+			estimatemax : this.estimatemax,
+			estimateexpected : this.estimateexpected
 		});
 	}
 }

--- a/lib/history.js
+++ b/lib/history.js
@@ -26,7 +26,6 @@ var History = function History(data)
 	this.estimatemax = 0;
 	this.estimateexpected = 0;
 
-
 }
 
 History.prototype.add = function(block, id, trusted, addingHistory)
@@ -506,6 +505,13 @@ History.prototype.updateStakeInfo = function(stats, callback) {
 	return callback(null, stats);
 }
 
+History.prototype.updateTicketsMempool = function(stats, callback) {
+
+	this.allmempooltix = stats.length;
+	
+	return callback(null, {allmempooltix:this.allmempooltix});
+}
+
 History.prototype.getEstimateMin = function()
 {
 	return this.estimatemin;
@@ -616,9 +622,9 @@ History.prototype.getCharts = function()
 			tixpoolsize : this.getTixPoolSize(),
 			allmempooltix : this.getMemPoolTix(),
 			stakedifficulty : this.getStakeDifficulty(),
-			estimatemin : this.estimatemin,
-			estimatemax : this.estimatemax,
-			estimateexpected : this.estimateexpected
+			estimatemin : this.getEstimateMin(),
+			estimatemax : this.getEstimateMax(),
+			estimateexpected : this.getEstimateExpected()
 		});
 	}
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -16,7 +16,7 @@ html {
 
 body {
 	width: 100%;
-	min-width: 1900px;
+	/*min-width: 1900px;*/
 	font-smooth: auto;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;

--- a/src/js/controllers.js
+++ b/src/js/controllers.js
@@ -23,7 +23,13 @@ netStatsApp.controller('StatsCtrl', function($scope, $filter, $localStorage, soc
 	$scope.supply = 0;
 	$scope.locked = 0;
 	$scope.blockReward = BLOCK_REWARD;
+	$scope.stakeReward = BLOCK_REWARD * 0.06;
 	$scope.bestStats = {};
+	$scope.poolsize = 0;
+	$scope.allmempooltix = 0;
+	$scope.estimatemin = 0;
+	$scope.estimatemax = 0;
+	$scope.estimateexpected = 0;
 
 	//$scope.lastGasLimit = _.fill(Array(MAX_BINS), 2);
 	$scope.lastBlocksTime = _.fill(Array(MAX_BINS), 2);
@@ -135,6 +141,7 @@ netStatsApp.controller('StatsCtrl', function($scope, $filter, $localStorage, soc
 					latencyFilter(node);
 
 					$scope.blockReward = getBlockReward(Math.ceil(node.stats.block.height / 6144) - 1, BLOCK_REWARD);
+					$scope.stakeReward = ($scope.blockReward) * 0.06;
 				});
 
 				if( $scope.nodes.length > 0 )
@@ -194,6 +201,8 @@ netStatsApp.controller('StatsCtrl', function($scope, $filter, $localStorage, soc
 					$scope.nodes[index].stats.block = data.block;
 					$scope.nodes[index].stats.propagationAvg = data.propagationAvg;
 					$scope.blockReward = getBlockReward(Math.ceil(data.block.height / 6144) - 1, BLOCK_REWARD);
+					$scope.stakeReward = ($scope.blockReward) * 0.06;
+					$scope.poolsize = data.poolsize;
 
 					updateBestBlock();
 				}
@@ -260,9 +269,22 @@ netStatsApp.controller('StatsCtrl', function($scope, $filter, $localStorage, soc
 				break;
 
 			case "mininginfo":
+				console.log(data.networkhashps);
 				$scope.avgHashrate = data.networkhashps;
 				$scope.pooledtx = data.pooledtx;
 
+				break;
+				
+			case "tiketsmempool":
+				$scope.allmempooltix = data.allmempooltix;
+
+				break;
+
+			case "estimatestakediff":
+				$scope.estimatemin = data.min;
+				$scope.estimatemax = data.max;
+				$scope.estimateexpected = data.expected;
+				
 				break;
 
 			case "charts":
@@ -272,6 +294,9 @@ netStatsApp.controller('StatsCtrl', function($scope, $filter, $localStorage, soc
 
 				if( !_.isEqual($scope.avgHashrate, data.avgHashrate) )
 					$scope.avgHashrate = data.avgHashrate;
+				console.log(data.avgHashrate);
+				console.log(data.networkhashps);
+
 
 				if( !_.isEqual($scope.lastBlocksTime, data.blocktime) && data.blocktime.length >= MAX_BINS ) 
 					$scope.lastBlocksTime = data.blocktime;
@@ -295,6 +320,18 @@ netStatsApp.controller('StatsCtrl', function($scope, $filter, $localStorage, soc
 				}).stats.block.height;
 
 				$scope.blockReward = getBlockReward(Math.ceil(bestHeight / 6144) - 1, BLOCK_REWARD);
+				$scope.stakeReward = ($scope.blockReward) * 0.06;
+				
+				// stake info
+				$scope.poolsize = data.poolsize;
+				var lastPoolsize = data.poolsize.slice(-1)[0];
+				$scope.printablePoolSize = Math.round(lastPoolsize).toString().replace(/(\d)(?=(\d\d\d)+([^\d]|$))/g, '$1 ');
+				$scope.allmempooltix = data.allmempooltix;
+				$scope.estimatemin = data.estimatemin;
+				$scope.estimatemax = data.estimatemax;
+				$scope.estimateexpected = data.estimateexpected;
+				$scope.avgTicketPrice = data.locked / lastPoolsize;
+				
 
 				break;
 

--- a/src/views/index.jade
+++ b/src/views/index.jade
@@ -7,19 +7,20 @@ block content
       div.col-xs-2.stat-holder
         div.big-info.bestblock.text-info
           div.pull-left.icon-full-width
-            i.icon-block
+            i.icon-gasprice
           div.big-details-holder
-            span.small-title best block
-            span.big-details {{'#'}}{{ bestBlock | number}}
+            span.small-title Ticket price
+              span.small 
+            span.big-details {{ (bestStats.block.sbits).toString().substr(0,5) }} DCR
           div.clearfix
       div.col-xs-2.stat-holder
         div.big-info.uncleCount(class="{{ bestStats.block.voters | votersClass }}")
           div.pull-left.icon-full-width
-            i.icon-group
+              i.icon-clock
           div.big-details-holder
-            span.small-title voters&nbsp;
+            span.small-title Price adjusts in 
               span.small 
-            span.big-details {{ bestStats.block.voters }}
+            span.big-details {{144 - bestStats.block.height % 144}} blocks
           div.clearfix
       div.col-xs-2.stat-holder
         div.big-info.blocktime(class="{{ lastBlock | timeClass : true }}")
@@ -38,23 +39,6 @@ block content
             span.small-title avg block time
             span.big-details {{ avgBlockTime | avgTimeFilter }}
           div.clearfix
-      div.col-xs-2.stat-holder
-        div.big-info.difficulty.text-orange
-          div.pull-left.icon-full-width
-            i.icon-hashrate
-          div.big-details-holder
-            span.small-title avg network hashrate
-            span.big-details(ng-bind-html="avgHashrate | networkHashrateFilter")
-          div.clearfix
-      div.col-xs-2.stat-holder
-        div.big-info.difficulty.text-danger
-          div.pull-left.icon-full-width
-            i.icon-difficulty
-          div.big-details-holder
-            span.small-title difficulty
-            span.big-details
-              span.small-hash {{ lastDifficulty | totalDifficultyFilter }}
-          div.clearfix
 
       div.clearfix
 
@@ -65,32 +49,58 @@ block content
           div.col-xs-2.stat-holder.box
             div.gasprice.text-info
               i.icon-gasprice
-              span.small-title Ticket price
-              span.small-value {{ (bestStats.block.sbits).toString().substr(0,5) }} DCR
-          div.col-xs-2.stat-holder.box
-            div.gasprice.text-info
-              i.icon-gasprice
               span.small-title Poolsize
               span.small-value {{ bestStats.block.poolsize }} tickets
           div.col-xs-2.stat-holder.box
-            div.active-nodes(class="text-success")
-              i.icon-clock
-              span.small-title Price adjusts in 
-              span.small-value {{144 - bestStats.block.height % 144}} blocks
+            div.gasprice.text-info
+              i.icon-block
+              span.small-title best block
+              span.small-value {{'#'}}{{ bestBlock | number}}
           div.col-xs-2.stat-holder.box
             div.active-nodes(class="text-success")
-              i.icon-uncle
-              span.small-title Mempool
-              span.small-value {{pooledtx}}
+              i.icon-difficulty
+              span.small-title difficulty
+              span.small-value {{ lastDifficulty | totalDifficultyFilter }}
           div.col-xs-2.stat-holder.box
             div.page-latency(class="{{ {active: true, latency: latency} | latencyClass }}")
               i.icon-clock
               span.small-title page latency
               span.small-value {{latency}} ms
 
+
+        div.row.second-row
+
+          div.col-xs-2.stat-holder.box
+            div.difficulty.text-info
+              i.icon-uncle
+              span.small-title Mempool
+              span.small-value {{pooledtx}}
+          div.col-xs-2.stat-holder.box
+            div.difficulty.text-info
+              i.icon-group
+              span.small-title voters&nbsp;
+              span.small-value {{ bestStats.block.voters }}
+          div.col-xs-2.stat-holder.box
+            div.active-nodes(class="text-success")
+              i.icon-hashrate
+              span.small-title avg hashrate
+              span.small-value(ng-bind-html="avgHashrate | networkHashrateFilter")
+          div.col-xs-2.stat-holder.box
+
+
         div.row
           div.col-xs-8
             div.row
+              div.col-xs-3.stat-holder
+                div.big-info.chart.text-info
+                  span.small-title freshstake
+                  sparkchart.big-details.spark-difficulty(data="{{freshstakeChart.join(',')}}")
+
+              div.col-xs-3.stat-holder
+                div.big-info.chart.text-info
+                  span.small-title voters
+                  sparkchart.big-details.spark-voters(data="{{votersChart.join(',')}}")
+
               div.col-xs-3.stat-holder
                 div.big-info.chart(class="{{ avgBlockTime | avgTimeClass }}")
                   //- i.icon-time
@@ -102,16 +112,6 @@ block content
                 div.big-info.chart.text-info
                   span.small-title transactions
                   sparkchart.big-details.spark-transactions(data="{{transactionDensity.join(',')}}")
-
-              div.col-xs-3.stat-holder
-                div.big-info.chart.text-info
-                  span.small-title voters
-                  sparkchart.big-details.spark-voters(data="{{votersChart.join(',')}}")
-
-              div.col-xs-3.stat-holder
-                div.big-info.chart.text-info
-                  span.small-title freshstake
-                  sparkchart.big-details.spark-difficulty(data="{{freshstakeChart.join(',')}}")
 
               div.col-xs-3.stat-holder
                 div.big-info.bottom-stats.text-success
@@ -149,13 +149,11 @@ block content
                     span.big-details(style="font-size: 38px; line-height: 45px;letter-spacing: -3px;white-space: nowrap;") {{ locked }}
                       span.smaller-text &nbsp;DCR
 
+          //div.clearfix
 
-
-          div.col-xs-4.stat-holder.map-holder
-            //- div.col-xs-12
-            nodemap#mapHolder(data="map")
 
     div.row(ng-cloak, style="padding-top: 10px")
+    div.col-xs-4.map-holder
       table.table.table-striped
         thead
           tr.text-info
@@ -180,3 +178,8 @@ block content
             td(class="{{ node.currentheight | blockHeight : bestBlock }}") # {{ node.currentheight }}
             td
               span.small {{ node.subver }}
+
+    div.col-xs-4.map-holder
+      //- div.col-xs-12
+      nodemap#mapHolder(data="map")
+

--- a/src/views/index.jade
+++ b/src/views/index.jade
@@ -11,7 +11,8 @@ block content
           div.big-details-holder
             span.small-title Ticket price
               span.small 
-            span.big-details {{ (bestStats.block.sbits).toString().substr(0,5) }} DCR
+            span.big-details {{ (bestStats.block.sbits).toString().substr(0,5) }}
+              span.smaller-text &nbsp;DCR
           div.clearfix
       div.col-xs-2.stat-holder
         div.big-info.uncleCount(class="{{ bestStats.block.voters | votersClass }}")
@@ -20,73 +21,98 @@ block content
           div.big-details-holder
             span.small-title Price adjusts in 
               span.small 
-            span.big-details {{144 - bestStats.block.height % 144}} blocks
+            span.big-details {{144 - bestStats.block.height % 144}} 
+              span.smaller-text blocks
           div.clearfix
       div.col-xs-2.stat-holder
-        div.big-info.blocktime(class="{{ lastBlock | timeClass : true }}")
+        div.big-info.blocktime.text-info
           div.pull-left.icon-full-width
-            i.icon-time
+            i.icon-mining
           div.big-details-holder
-            span.small-title last block
-            span.big-details {{ lastBlock | blockTimeFilter }}
-            //- span.big-details(time-ago="lastBlock")
+            span.small-title block reward
+            span.big-details {{blockReward.toString().substr(0,5)}}
+              span.smaller-text &nbsp;DCR
           div.clearfix
       div.col-xs-2.stat-holder
-        div.big-info.avgblocktime(class="{{ avgBlockTime | avgTimeClass }}")
+        div.big-info.avgblocktime.text-info
           div.pull-left.icon-full-width
-            i.icon-gas
+            i.icon-gasprice
           div.big-details-holder
-            span.small-title avg block time
-            span.big-details {{ avgBlockTime | avgTimeFilter }}
+            span.small-title Ticket Pool Size
+            span.big-details {{ printablePoolSize }} 
+              span.smaller-text tickets
           div.clearfix
-
-      div.clearfix
 
 
     div.row(ng-cloak)
       div.col-xs-12.stats-boxes(style="padding-top: 0px;")
+
+        // small columns
         div.row.second-row
           div.col-xs-2.stat-holder.box
             div.gasprice.text-info
               i.icon-gasprice
-              span.small-title Poolsize
-              span.small-value {{ bestStats.block.poolsize }} tickets
+              span.small-title next price
+              span.small-value {{ estimateexpected.toString().substr(0,5) }}&nbsp;DCR
+          div.col-xs-2.stat-holder.box
+            div.blocktime(class="{{ lastBlock | timeClass : true }}")
+              i.icon-time
+              span.small-title last block
+              span.small-value {{ lastBlock | blockTimeFilter }}
+          div.col-xs-2.stat-holder.box
+            div.active-nodes.text-info
+              i.icon-mining
+              span.small-title stake reward
+              span.small-value {{ stakeReward.toString().substr(0,5) }}&nbsp;DCR
+          div.col-xs-2.stat-holder.box
+            div.page-latency.text-info
+              i.icon-uncle
+              span.small-title Ticket Mempool
+              span.small-value {{ allmempooltix }} tickets
+
+        div.row.second-row
+          div.col-xs-2.stat-holder.box
+            div.gasprice.text-success
+              i.icon-gasprice
+              span.small-title min price
+              span.small-value {{ estimatemin.toString().substr(0,5) }}&nbsp;DCR
+          div.col-xs-2.stat-holder.box
+            div.avgblocktime(class="{{ avgBlockTime | avgTimeClass }}")
+              i.icon-clock
+              span.small-title avg block time
+              span.small-value {{ avgBlockTime | avgTimeFilter }}
+          div.col-xs-2.stat-holder.box
+            div.active-nodes.text-success
+              i.icon-clock
+              span.small-title adjusts in
+              span.small-value {{6144 - bestStats.block.height % 6144}}&nbsp;blocks
+          div.col-xs-2.stat-holder.box
+            div.difficulty.text-success
+              i.icon-gas
+              span.small-title locked dcr
+              span.small-value {{ locked }}&nbsp;DCR
+
+        div.row.second-row
+          div.col-xs-2.stat-holder.box
+            div.gasprice.text-warning
+              i.icon-gasprice
+              span.small-title max price
+              span.small-value {{ estimatemax.toString().substr(0,5) }}&nbsp;DCR
           div.col-xs-2.stat-holder.box
             div.gasprice.text-info
               i.icon-block
               span.small-title best block
               span.small-value {{'#'}}{{ bestBlock | number}}
           div.col-xs-2.stat-holder.box
-            div.active-nodes(class="text-success")
-              i.icon-difficulty
-              span.small-title difficulty
-              span.small-value {{ lastDifficulty | totalDifficultyFilter }}
+            div.active-nodes.text-warning
+              i.decred-font-logo A
+              span.small-title available supply
+              span.small-value {{ supply }}&nbsp;DCR
           div.col-xs-2.stat-holder.box
-            div.page-latency(class="{{ {active: true, latency: latency} | latencyClass }}")
-              i.icon-clock
-              span.small-title page latency
-              span.small-value {{latency}} ms
-
-
-        div.row.second-row
-
-          div.col-xs-2.stat-holder.box
-            div.difficulty.text-info
-              i.icon-uncle
-              span.small-title Mempool
-              span.small-value {{pooledtx}}
-          div.col-xs-2.stat-holder.box
-            div.difficulty.text-info
-              i.icon-group
-              span.small-title voters&nbsp;
-              span.small-value {{ bestStats.block.voters }}
-          div.col-xs-2.stat-holder.box
-            div.active-nodes(class="text-success")
-              i.icon-hashrate
-              span.small-title avg hashrate
-              span.small-value(ng-bind-html="avgHashrate | networkHashrateFilter")
-          div.col-xs-2.stat-holder.box
-
+            div.gasprice.text-warning
+              i.icon-gasprice
+              span.small-title Avg Ticket Price
+              span.small-value {{ avgTicketPrice.toString().substr(0,5) }}&nbsp;DCR
 
         div.row
           div.col-xs-8
@@ -112,45 +138,28 @@ block content
                 div.big-info.chart.text-info
                   span.small-title transactions
                   sparkchart.big-details.spark-transactions(data="{{transactionDensity.join(',')}}")
-
-              div.col-xs-3.stat-holder
-                div.big-info.bottom-stats.text-success
-                  div.pull-left.icon-full-width
-                    i.decred-font-logo(style="margin: 0;") A
-                  div.big-details-holder
-                    span.small-title block reward
-                    span.big-details(style="font-size: 40px; line-height: 45px;letter-spacing: -3px;white-space: nowrap;") {{blockReward.toString().substr(0,5)}} 
-                      span.smaller-text &nbsp;DCR
-
-              div.col-xs-3.stat-holder
-                div.big-info.bottom-stats.text-success
-                  div.pull-left.icon-full-width
-                    i.icon-clock
-                  div.big-details-holder
-                    span.small-title reward adjustment in
-                    span.big-details(style="font-size: 40px; line-height: 45px;letter-spacing: -3px;white-space: nowrap;") {{6144 - bestStats.block.height % 6144}} 
-                      span.smaller-text &nbsp;blocks
-
-              div.col-xs-3.stat-holder
-                div.big-info.bottom-stats.text-success
-                  div.pull-left.icon-full-width
-                    i.icon-network
-                  div.big-details-holder
-                    span.small-title available supply
-                    span.big-details(style="font-size: 38px; line-height: 45px;letter-spacing: -3px;white-space: nowrap;") {{ supply }}
-                      span.smaller-text &nbsp;DCR
-
-              div.col-xs-3.stat-holder
-                div.big-info.bottom-stats.text-success
-                  div.pull-left.icon-full-width
-                    i.icon-mining
-                  div.big-details-holder
-                    span.small-title locked dcr
-                    span.big-details(style="font-size: 38px; line-height: 45px;letter-spacing: -3px;white-space: nowrap;") {{ locked }}
-                      span.smaller-text &nbsp;DCR
-
-          //div.clearfix
-
+ 
+        div.row.second-row
+          div.col-xs-2.stat-holder.box
+            div.active-nodes.text-success
+              i.icon-difficulty
+              span.small-title PoW difficulty
+              span.small-value {{ lastDifficulty | totalDifficultyFilter }}
+          div.col-xs-2.stat-holder.box
+            div.active-nodes.text-success
+              i.icon-hashrate
+              span.small-title avg hashrate
+              span.small-value(ng-bind-html="avgHashrate | networkHashrateFilter")
+          div.col-xs-2.stat-holder.box
+            div.active-nodes.text-success
+              i.icon-mining
+              span.small-title PoW reward
+              span.small-value {{ (blockReward * 0.6).toString().substr(0,5) }}&nbsp;DCR
+          div.col-xs-2.stat-holder.box
+            div.page-latency(class="{{ {active: true, latency: latency} | latencyClass }}")
+              i.icon-clock
+              span.small-title page latency
+              span.small-value {{latency}} ms
 
     div.row(ng-cloak, style="padding-top: 10px")
     div.col-xs-4.map-holder

--- a/src/views/index.jade
+++ b/src/views/index.jade
@@ -2,9 +2,10 @@
 extends ./layout.jade
 
 block content
-  div.container-fluid(ng-controller='StatsCtrl')
+
+  div.container-fluid(ng-controller='StatsCtrl', role="main")
     div.row(ng-cloak)
-      div.col-xs-2.stat-holder
+      div.col-xs-3.stat-holder
         div.big-info.bestblock.text-info
           div.pull-left.icon-full-width
             i.icon-gasprice
@@ -14,7 +15,7 @@ block content
             span.big-details {{ (bestStats.block.sbits).toString().substr(0,5) }}
               span.smaller-text &nbsp;DCR
           div.clearfix
-      div.col-xs-2.stat-holder
+      div.col-xs-3.stat-holder
         div.big-info.uncleCount(class="{{ bestStats.block.voters | votersClass }}")
           div.pull-left.icon-full-width
               i.icon-clock
@@ -24,7 +25,7 @@ block content
             span.big-details {{144 - bestStats.block.height % 144}} 
               span.smaller-text blocks
           div.clearfix
-      div.col-xs-2.stat-holder
+      div.col-xs-3.stat-holder
         div.big-info.blocktime.text-info
           div.pull-left.icon-full-width
             i.icon-mining
@@ -33,7 +34,7 @@ block content
             span.big-details {{blockReward.toString().substr(0,5)}}
               span.smaller-text &nbsp;DCR
           div.clearfix
-      div.col-xs-2.stat-holder
+      div.col-xs-3.stat-holder
         div.big-info.avgblocktime.text-info
           div.pull-left.icon-full-width
             i.icon-gasprice
@@ -49,120 +50,120 @@ block content
 
         // small columns
         div.row.second-row
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.gasprice.text-info
               i.icon-gasprice
               span.small-title next price
               span.small-value {{ estimateexpected.toString().substr(0,5) }}&nbsp;DCR
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.blocktime(class="{{ lastBlock | timeClass : true }}")
               i.icon-time
               span.small-title last block
               span.small-value {{ lastBlock | blockTimeFilter }}
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.active-nodes.text-info
               i.icon-mining
               span.small-title stake reward
               span.small-value {{ stakeReward.toString().substr(0,5) }}&nbsp;DCR
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.page-latency.text-info
               i.icon-uncle
               span.small-title Ticket Mempool
               span.small-value {{ allmempooltix }} tickets
 
         div.row.second-row
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.gasprice.text-success
               i.icon-gasprice
               span.small-title min price
               span.small-value {{ estimatemin.toString().substr(0,5) }}&nbsp;DCR
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.avgblocktime(class="{{ avgBlockTime | avgTimeClass }}")
               i.icon-clock
               span.small-title avg block time
               span.small-value {{ avgBlockTime | avgTimeFilter }}
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.active-nodes.text-success
               i.icon-clock
               span.small-title adjusts in
               span.small-value {{6144 - bestStats.block.height % 6144}}&nbsp;blocks
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.difficulty.text-success
               i.icon-gas
               span.small-title locked dcr
               span.small-value {{ locked }}&nbsp;DCR
 
         div.row.second-row
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.gasprice.text-warning
               i.icon-gasprice
               span.small-title max price
               span.small-value {{ estimatemax.toString().substr(0,5) }}&nbsp;DCR
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.gasprice.text-info
               i.icon-block
               span.small-title best block
               span.small-value {{'#'}}{{ bestBlock | number}}
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.active-nodes.text-warning
               i.decred-font-logo A
               span.small-title available supply
               span.small-value {{ supply }}&nbsp;DCR
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.gasprice.text-warning
               i.icon-gasprice
               span.small-title Avg Ticket Price
               span.small-value {{ avgTicketPrice.toString().substr(0,5) }}&nbsp;DCR
 
         div.row
-          div.col-xs-8
-            div.row
-              div.col-xs-3.stat-holder
-                div.big-info.chart.text-info
-                  span.small-title freshstake
-                  sparkchart.big-details.spark-difficulty(data="{{freshstakeChart.join(',')}}")
+          //div.col-xs-8
+          //div.row
+          div.col-xs-3.stat-holder
+            div.big-info.chart.text-info
+              span.small-title freshstake
+              sparkchart.big-details.spark-difficulty(data="{{freshstakeChart.join(',')}}")
 
-              div.col-xs-3.stat-holder
-                div.big-info.chart.text-info
-                  span.small-title voters
-                  sparkchart.big-details.spark-voters(data="{{votersChart.join(',')}}")
+          div.col-xs-3.stat-holder
+            div.big-info.chart.text-info
+              span.small-title voters
+              sparkchart.big-details.spark-voters(data="{{votersChart.join(',')}}")
 
-              div.col-xs-3.stat-holder
-                div.big-info.chart(class="{{ avgBlockTime | avgTimeClass }}")
-                  //- i.icon-time
-                  span.small-title block time
-                  //- span.small-value {{ avgBlockTime | avgTimeFilter }}
-                  sparkchart.big-details.spark-blocktimes(data="{{lastBlocksTime.join(',')}}", tooltipsuffix="s")
+          div.col-xs-3.stat-holder
+            div.big-info.chart(class="{{ avgBlockTime | avgTimeClass }}")
+              //- i.icon-time
+              span.small-title block time
+              //- span.small-value {{ avgBlockTime | avgTimeFilter }}
+              sparkchart.big-details.spark-blocktimes(data="{{lastBlocksTime.join(',')}}", tooltipsuffix="s")
 
-              div.col-xs-3.stat-holder
-                div.big-info.chart.text-info
-                  span.small-title transactions
-                  sparkchart.big-details.spark-transactions(data="{{transactionDensity.join(',')}}")
- 
+          div.col-xs-3.stat-holder
+            div.big-info.chart.text-info
+              span.small-title transactions
+              sparkchart.big-details.spark-transactions(data="{{transactionDensity.join(',')}}")
+
         div.row.second-row
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.active-nodes.text-success
               i.icon-difficulty
               span.small-title PoW difficulty
               span.small-value {{ lastDifficulty | totalDifficultyFilter }}
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.active-nodes.text-success
               i.icon-hashrate
               span.small-title avg hashrate
               span.small-value(ng-bind-html="avgHashrate | networkHashrateFilter")
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.active-nodes.text-success
               i.icon-mining
               span.small-title PoW reward
               span.small-value {{ (blockReward * 0.6).toString().substr(0,5) }}&nbsp;DCR
-          div.col-xs-2.stat-holder.box
+          div.col-xs-3.stat-holder.box
             div.page-latency(class="{{ {active: true, latency: latency} | latencyClass }}")
               i.icon-clock
               span.small-title page latency
               span.small-value {{latency}} ms
 
     div.row(ng-cloak, style="padding-top: 10px")
-    div.col-xs-4.map-holder
+    div.col-xs-6.map-holder
       table.table.table-striped
         thead
           tr.text-info
@@ -188,7 +189,7 @@ block content
             td
               span.small {{ node.subver }}
 
-    div.col-xs-4.map-holder
+    div.col-xs-6.map-holder
       //- div.col-xs-12
       nodemap#mapHolder(data="map")
 


### PR DESCRIPTION
So, i added some info to the dashboard, did some optimizations and reorganized the UI so it runs on an "iframe" on my pool. The mains changes are:
- added id to all rpc calls, so we can identify answers by id, and not by guessing based on the data returned.
- getticketpoolvalue is no longer timed, but is called whenever a new block is found. This improves performance quite a bit.
- added calls to estimatestakediff and ticketsmempool
- calculates average ticket price using getticketpoolvalue and getblock.poolsize
